### PR TITLE
feat: handle NoCall transactions as delay calls

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -37,8 +37,23 @@ func parseTransactions(transactions types.EchidnaReproducer) ([]types.ParsedCall
 	var calls []types.ParsedCall
 
 	for _, tx := range transactions {
-		// Skip NoCall transactions (they represent time delays)
+		// Handle NoCall transactions (they represent pure time delays)
 		if tx.Call.Tag == "NoCall" {
+			hasDelay, delayValue := parseDelay(tx.Delay)
+			if hasDelay {
+				delayCall := types.ParsedCall{
+					FunctionName: "", // Empty function name for pure delays
+					Parameters:   []types.ParsedParam{},
+					Dst:          tx.Dst,
+					Src:          tx.Src,
+					Value:        tx.Value,
+					Gas:          tx.Gas,
+					GasPrice:     tx.GasPrice,
+					HasDelay:     true,
+					DelayValue:   delayValue,
+				}
+				calls = append(calls, delayCall)
+			}
 			continue
 		}
 


### PR DESCRIPTION
## What does this PR do?
Adds support for NoCall transactions in Echidna reproducer files. Previously, NoCall transactions (which represent pure time delays) were skipped entirely. Now they are converted to `_delay()` calls in the generated Foundry tests.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other: ___________

## Testing
- [X] Tests pass (`make test`)
- [X] Builds successfully (`make build`)
- [X] Tested manually (if applicable)

## Additional notes
- NoCall transactions contain only delay information and no function calls
- The parser now creates ParsedCall objects with `HasDelay: true` and empty `FunctionName`
- The existing generator logic already handles delay-only calls correctly
- This makes generated tests more accurate to the original Echidna fuzzing sequences